### PR TITLE
fix: Fixed dashboard not connecting to mongodb

### DIFF
--- a/lua/taka-time/init.lua
+++ b/lua/taka-time/init.lua
@@ -74,7 +74,8 @@ function M.setup(opts)
     -- or provide the absolute path to the binary here.
     local cmd = string.format("%s --MongoDBString '%s'", bin_path, uri)
 
-    vim.fn.termopen(cmd, {
+    vim.fn.jobstart(cmd, {
+      term = true,
       on_exit = function()
         -- When you press 'q' or 'esc' in the dashboard, it exits the Go binary.
         -- This hook automatically closes the Neovim floating window behind it!

--- a/lua/taka-time/init.lua
+++ b/lua/taka-time/init.lua
@@ -38,7 +38,6 @@ function M.setup(opts)
   vim.api.nvim_create_user_command("TakaDash", function()
     -- 1. Ensure the user has actually configured their URI
     local uri = config.options.mongo_uri
-    print("[debug] URI=" .. uri)
     if not uri or uri == "" then
       print("TakaTime: Missing MongoDB URI. Please run :TakaInit first!")
       return
@@ -73,7 +72,7 @@ function M.setup(opts)
     -- 5. Construct the command and launch the terminal!
     -- NOTE: Make sure 'taka-dash' is either in your system PATH,
     -- or provide the absolute path to the binary here.
-    local cmd = string.format("%s --MongoDBString '%s'", bin_path, uri)
+    local cmd = string.format("%s --MongoDBString \"%s\"", bin_path, uri)
 
     vim.fn.jobstart(cmd, {
       term = true,

--- a/lua/taka-time/init.lua
+++ b/lua/taka-time/init.lua
@@ -38,6 +38,7 @@ function M.setup(opts)
   vim.api.nvim_create_user_command("TakaDash", function()
     -- 1. Ensure the user has actually configured their URI
     local uri = config.options.mongo_uri
+    print("[debug] URI=" .. uri)
     if not uri or uri == "" then
       print("TakaTime: Missing MongoDB URI. Please run :TakaInit first!")
       return


### PR DESCRIPTION
### Changed

- Changed deprecated `vim.fn.termopen` function to `vim.fn.jobstart` with `term = true`
- Changed single quotes to double quotes on the cmd args