### PR TITLE
fix: track.ipynb notebook files in VS Code

### DIFF
--- a/vscodePlugin/Takatime/extension.js
+++ b/vscodePlugin/Takatime/extension.js
@@ -64,13 +64,17 @@ async function activate(context) {
 
   context.subscriptions.push(saveListener);
 
-  // 3b. Notebook Save Listener (.ipynb files)
+  // 3b. Notebook Save Listener
   const notebookSaveListener = vscode.workspace.onDidSaveNotebookDocument((notebook) => {
+    // Filter out junk
+    if (notebook.uri.scheme !== "file") return;
+    if (notebook.uri.fsPath.includes(path.sep + ".git" + path.sep)) return;
+    
     // Construct a minimal document-like object so handleHeartbeat works unchanged
     const mockDocument = {
       fileName: notebook.uri.fsPath,
       uri: notebook.uri,
-      languageId: "jupyter-notebook"
+      languageId: notebook.notebookType || "unknown-notebook"
     };
     heartbeat.handleHeartbeat(mockDocument);
   });

--- a/vscodePlugin/Takatime/extension.js
+++ b/vscodePlugin/Takatime/extension.js
@@ -64,6 +64,19 @@ async function activate(context) {
 
   context.subscriptions.push(saveListener);
 
+  // 3b. Notebook Save Listener (.ipynb files)
+  const notebookSaveListener = vscode.workspace.onDidSaveNotebookDocument((notebook) => {
+    // Construct a minimal document-like object so handleHeartbeat works unchanged
+    const mockDocument = {
+      fileName: notebook.uri.fsPath,
+      uri: notebook.uri,
+      languageId: "jupyter-notebook"
+    };
+    heartbeat.handleHeartbeat(mockDocument);
+  });
+
+  context.subscriptions.push(notebookSaveListener);
+
   // 4. Initial Check
   statusHelper.checkStatus(statusBar);
 }


### PR DESCRIPTION
**Problem**: Notebook files opened in VS Code's notebook editor aren't tracked by TakaTime because notebook documents use onDidSaveNotebookDocument rather than the standard text document events the extension currently listens to.

**Fix**: Added listeners for notebook save events, forwarding the notebook file path to the existing heartbeat function.

**To test**: Open any notebook (such as a .ipynb) file in VS Code with the Jupyter extension installed, make a change in a cell, save, and verify the activity appears in the TakaTime dashboard or MongoDB Database.

