### PR TITLE
Fix/tracktyping universaldelay pr

### DIFF
--- a/vscodePlugin/Takatime/Plugin/HeartBeat.js
+++ b/vscodePlugin/Takatime/Plugin/HeartBeat.js
@@ -3,7 +3,7 @@ const uploader = require("./Uploader");
 const vscode = require("vscode");
 
 // Key: File Path, Value: Last Timestamp (ms)
-const fileTimestamps = new Map();
+let lastHeartbeatTime = 0;
 
 // ⏳ THE COOLDOWN (Standard is 2 minutes)
 const COOLDOWN_MS = 120 * 1000;
@@ -16,21 +16,15 @@ const COOLDOWN_MS = 120 * 1000;
 function handleHeartbeat(document) {
   const filePath = document.fileName;
   const now = Date.now();
-  const lastSaved = fileTimestamps.get(filePath) || 0;
-
-  // 1. Check Debounce/Throttle
-  // If it hasn't been 2 mins since the last ping for THIS file...
-  if (now - lastSaved < COOLDOWN_MS) {
-    // ... We skip it. (Optional: Log it for debugging)
-    // console.log("TakaTime: Debounced (Skipped)");
-    return;
-  }
+  
+  // 1. Check Cooldown
+  if (now - lastHeartbeatTime < COOLDOWN_MS) return;
 
   // 2. Fire the Upload
   uploader.spawnProcess(document);
 
-  // 3. Reset the Timer for this file
-  fileTimestamps.set(filePath, now);
+  // 3. Reset the Timer
+  lastHeartbeatTime = now;
 }
 
 module.exports = { handleHeartbeat };

--- a/vscodePlugin/Takatime/Plugin/HeartBeat.js
+++ b/vscodePlugin/Takatime/Plugin/HeartBeat.js
@@ -1,6 +1,7 @@
 // Plugin/HeartBeat.js
 const uploader = require("./Uploader");
-const vscode = require("vscode");
+
+/** @typedef {import('vscode').TextDocument} TextDocument */
 
 // Last heartbeat timestamp (ms), shared globally across all files
 let lastHeartbeatTime = 0;
@@ -11,7 +12,7 @@ const COOLDOWN_MS = 120 * 1000;
 /**
  * Handles the "Heartbeat" logic.
  * Decides if we should actually call the binary or just ignore the event.
- * @param {vscode.TextDocument} document
+ * @param {TextDocument} document
  */
 function handleHeartbeat(document) {
   const now = Date.now();

--- a/vscodePlugin/Takatime/Plugin/HeartBeat.js
+++ b/vscodePlugin/Takatime/Plugin/HeartBeat.js
@@ -1,8 +1,8 @@
-// Plugin/Heartbeat.js
+// Plugin/HeartBeat.js
 const uploader = require("./Uploader");
 const vscode = require("vscode");
 
-// Key: File Path, Value: Last Timestamp (ms)
+// Last heartbeat timestamp (ms), shared globally across all files
 let lastHeartbeatTime = 0;
 
 // ⏳ THE COOLDOWN (Standard is 2 minutes)
@@ -14,16 +14,15 @@ const COOLDOWN_MS = 120 * 1000;
  * @param {vscode.TextDocument} document
  */
 function handleHeartbeat(document) {
-  const filePath = document.fileName;
   const now = Date.now();
   
   // 1. Check Cooldown
   if (now - lastHeartbeatTime < COOLDOWN_MS) return;
 
-  // 2. Fire the Upload
-  uploader.spawnProcess(document);
+  // 2. Fire the Upload - returns if failed
+  if (!uploader.spawnProcess(document)) return;
 
-  // 3. Reset the Timer
+  // 3. Reset the Timer 
   lastHeartbeatTime = now;
 }
 

--- a/vscodePlugin/Takatime/Plugin/Uploader.js
+++ b/vscodePlugin/Takatime/Plugin/Uploader.js
@@ -61,7 +61,7 @@ function spawnProcess(document) {
     console.warn(
       `TakaTime: Binary not found at ${binaryPath}, skipping upload.`,
     );
-    return;
+    return false;
   }
 
   // 2. Spawn (Fire & Forget)
@@ -79,8 +79,10 @@ function spawnProcess(document) {
     });
     child.unref();
     console.log(`TakaTime: Uploading ${path.basename(document.fileName)}...`);
+    return true;
   } catch (err) {
     console.error("TakaTime: Failed to spawn process", err);
+    return false;
   }
 }
 

--- a/vscodePlugin/Takatime/extension.js
+++ b/vscodePlugin/Takatime/extension.js
@@ -52,7 +52,7 @@ async function activate(context) {
 
   context.subscriptions.push(dashStatusBar);
 
-  // 3. ⚡ SAVE LISTENER (Now with Heartbeat Logic!)
+  // 3a. Text-document Save Listener
   const saveListener = vscode.workspace.onDidSaveTextDocument((document) => {
     // Filter out junk
     if (document.uri.scheme !== "file") return;
@@ -64,7 +64,21 @@ async function activate(context) {
 
   context.subscriptions.push(saveListener);
 
-  // 3b. Notebook Save Listener
+  // 3b. Text-document typing Listener
+  const typingListener = vscode.workspace.onDidChangeTextDocument((event) => {
+    const document = event.document;
+
+    // Filter out junk
+    if (document.uri.scheme !== "file") return;
+    if (document.fileName.includes(path.sep + ".git" + path.sep)) return;
+    if (event.contentChanges.length === 0) return; // ignore no-op changes
+
+    heartbeat.handleHeartbeat(document); 
+  });
+
+  context.subscriptions.push(typingListener);
+
+  // 3c. Notebook Save Listener
   const notebookSaveListener = vscode.workspace.onDidSaveNotebookDocument((notebook) => {
     // Filter out junk
     if (notebook.uri.scheme !== "file") return;
@@ -80,6 +94,25 @@ async function activate(context) {
   });
 
   context.subscriptions.push(notebookSaveListener);
+
+  // 3d. Notebook Typing Listener
+  const notebookTypingListener = vscode.workspace.onDidChangeNotebookDocument((event) => {
+    const notebook = event.notebook;
+
+    // Filter out junk
+    if (notebook.uri.scheme !== "file") return;
+    if (notebook.uri.fsPath.includes(path.sep + ".git" + path.sep)) return;
+    if (event.contentChanges.length === 0 && event.cellChanges.length === 0) return;
+
+    const mockDocument = {
+      fileName: notebook.uri.fsPath,
+      uri: notebook.uri,
+      languageId: notebook.notebookType || "unknown-notebook"
+    };
+    heartbeat.handleHeartbeat(mockDocument);
+  });
+
+  context.subscriptions.push(notebookTypingListener);
 
   // 4. Initial Check
   statusHelper.checkStatus(statusBar);

--- a/vscodePlugin/Takatime/extension.js
+++ b/vscodePlugin/Takatime/extension.js
@@ -73,7 +73,7 @@ async function activate(context) {
     if (document.fileName.includes(path.sep + ".git" + path.sep)) return;
     if (event.contentChanges.length === 0) return; // ignore no-op changes
 
-    heartbeat.handleHeartbeat(document); 
+    heartbeat.handleHeartbeat(document);
   });
 
   context.subscriptions.push(typingListener);


### PR DESCRIPTION
Two main changes to the VSCode extension:
1. Added typing listeners using onDidChangeTextDocument and onDidChangeNotebookDocument to potentially trigger a heartbeat when the user types, not just saves.
2. Refactored HeartBeat.js to use a universal two-minute timer instead of a per-file timer. Now, when a user makes a change to a file (by typing or saving), a heartbeat will fire only if none have been fired in the last two minutes.