### PR TITLE
Fix mobile responsiveness in theme builder

### DIFF
--- a/docs/index.css
+++ b/docs/index.css
@@ -1,5 +1,11 @@
 @import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;700&family=Inter:wght@400;500;600;700&display=swap");
 
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
 body {
   background-color: #0d1117;
   color: #c9d1d9;
@@ -10,6 +16,7 @@ body {
   min-height: 100vh;
   margin: 0;
   padding: 0;
+  overflow-x: hidden;
 }
 
 @keyframes slideUpFade {

--- a/docs/index.html
+++ b/docs/index.html
@@ -199,7 +199,6 @@
 </p>
     <main
       class="flex-1 flex flex-col xl:flex-row gap-6 p-4 md:p-6 lg:p-10 max-w-[1800px] w-full mx-auto"
-      style="max-width: 100vw"
     >
       <aside
         class="w-full xl:w-[350px] 2xl:w-[400px] flex-shrink-0 animate-slide-up delay-100"
@@ -410,7 +409,7 @@
           <div
             id="dummyCard"
             class="dummy-card flex flex-col pt-4 px-4 pb-2"
-            style="min-width: 650px; width: 100%; max-width: 900px"
+            style="width: 100%; max-width: 900px"
           >
             <h2
               id="cardTitle"

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "docs",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "TakaTime",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/vscodePlugin/package-lock.json
+++ b/vscodePlugin/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "vscodePlugin",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
## Description
This PR fixes horizontal scrolling and layout overflow issues in the TakaTime Theme Builder on mobile devices. The entire page is now fully responsive down to 320px with zero horizontal scroll.

## Related Issue
[Issue 39](https://github.com/Rtarun3606k/TakaTime/issues/39)

## Changes
- The main container is now responsive as per the actual usable viewport width on all devices.
- Updated container padding for mobile screens.
- Fixed horizontal overflow in preview stat cards.
- Improved responsive layout behavior.
- Ensured layouts stack properly on smaller devices.
- Verified that no horizontal scrolling occurs down to 320px width.

## Screenshots

Before:
<img width="438" height="762" alt="image" src="https://github.com/user-attachments/assets/2fd2e94a-2dea-4429-81be-fc3a2f42f71d" />

After:
<img width="440" height="761" alt="image" src="https://github.com/user-attachments/assets/3b7de40e-fa52-49d9-9116-5d5f5e9b8afb" />


##  Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update