### PR TITLE
feat: add taka-export command for CSV/JSON data export (#56)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,10 @@ name: Build & Release Binaries
 on:
   release:
     types: [created]
+
 permissions:
   contents: write
+
 jobs:
   build-and-release:
     runs-on: ubuntu-latest
@@ -19,28 +21,37 @@ jobs:
       - name: Download Dependencies
         run: go mod download
 
-      # --- BUILD TAKA-UPLOAD (For Lua Plugin) ---
-      # --- BUILD TAKA-UPLOAD (For VS Code & Lua Plugin) ---
+      # --- BUILD TAKA-UPLOAD (For Lua Plugin & VS Code Plugin) ---
       - name: Build Taka-Upload
         run: |
-          env GOOS=linux GOARCH=amd64 go build  -trimpath -ldflags="-s -w -buildid=" -o taka-upload-linux-amd64 cmd/upload/main.go
-          env GOOS=darwin GOARCH=amd64 go build -trimpath -ldflags="-s -w -buildid=" -o taka-upload-darwin-amd64 cmd/upload/main.go
-          env GOOS=darwin GOARCH=arm64 go build -trimpath -ldflags="-s -w -buildid=" -o taka-upload-darwin-arm64 cmd/upload/main.go
-          env GOOS=windows GOARCH=amd64 go build -trimpath -ldflags="-s -w -buildid=" -o taka-upload-windows-amd64.exe cmd/upload/main.go
+          env GOOS=linux   GOARCH=amd64 go build -trimpath -ldflags="-s -w -buildid=" -o taka-upload-linux-amd64        cmd/upload/main.go
+          env GOOS=darwin  GOARCH=amd64 go build -trimpath -ldflags="-s -w -buildid=" -o taka-upload-darwin-amd64       cmd/upload/main.go
+          env GOOS=darwin  GOARCH=arm64 go build -trimpath -ldflags="-s -w -buildid=" -o taka-upload-darwin-arm64       cmd/upload/main.go
+          env GOOS=windows GOARCH=amd64 go build -trimpath -ldflags="-s -w -buildid=" -o taka-upload-windows-amd64.exe  cmd/upload/main.go
 
       # --- BUILD TAKA-REPORT (For Stats Generation) ---
       - name: Build Taka-Report
         run: |
-          env GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-s -w -buildid=" -o taka-report-linux-amd64 cmd/report/main.go
-          env GOOS=darwin GOARCH=amd64 go build -trimpath -ldflags="-s -w -buildid=" -o taka-report-darwin-amd64 cmd/report/main.go
-          env GOOS=darwin GOARCH=arm64 go build -trimpath -ldflags="-s -w -buildid=" -o taka-report-darwin-arm64 cmd/report/main.go
-          env GOOS=windows GOARCH=amd64 go build -trimpath -ldflags="-s -w -buildid=" -o taka-report-windows-amd64.exe cmd/report/main.go
+          env GOOS=linux   GOARCH=amd64 go build -trimpath -ldflags="-s -w -buildid=" -o taka-report-linux-amd64        cmd/report/main.go
+          env GOOS=darwin  GOARCH=amd64 go build -trimpath -ldflags="-s -w -buildid=" -o taka-report-darwin-amd64       cmd/report/main.go
+          env GOOS=darwin  GOARCH=arm64 go build -trimpath -ldflags="-s -w -buildid=" -o taka-report-darwin-arm64       cmd/report/main.go
+          env GOOS=windows GOARCH=amd64 go build -trimpath -ldflags="-s -w -buildid=" -o taka-report-windows-amd64.exe  cmd/report/main.go
+
+      # --- BUILD TAKA-DASHBOARD ---
       - name: Build Taka-Dashboard
         run: |
-          env GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-s -w -buildid=" -o taka-dashboard-linux-amd64 ./cmd/dashboard
-          env GOOS=darwin GOARCH=amd64 go build -trimpath -ldflags="-s -w -buildid=" -o taka-dashboard-darwin-amd64 ./cmd/dashboard
-          env GOOS=darwin GOARCH=arm64 go build -trimpath -ldflags="-s -w -buildid=" -o taka-dashboard-darwin-arm64 ./cmd/dashboard
-          env GOOS=windows GOARCH=amd64 go build -trimpath -ldflags="-s -w -buildid=" -o taka-dashboard-windows-amd64.exe ./cmd/dashboard
+          env GOOS=linux   GOARCH=amd64 go build -trimpath -ldflags="-s -w -buildid=" -o taka-dashboard-linux-amd64        ./cmd/dashboard
+          env GOOS=darwin  GOARCH=amd64 go build -trimpath -ldflags="-s -w -buildid=" -o taka-dashboard-darwin-amd64       ./cmd/dashboard
+          env GOOS=darwin  GOARCH=arm64 go build -trimpath -ldflags="-s -w -buildid=" -o taka-dashboard-darwin-arm64       ./cmd/dashboard
+          env GOOS=windows GOARCH=amd64 go build -trimpath -ldflags="-s -w -buildid=" -o taka-dashboard-windows-amd64.exe  ./cmd/dashboard
+
+      # --- BUILD TAKA-EXPORT (Data Export: CSV / JSON) ---
+      - name: Build Taka-Export
+        run: |
+          env GOOS=linux   GOARCH=amd64 go build -trimpath -ldflags="-s -w -buildid=" -o taka-export-linux-amd64        ./cmd/export
+          env GOOS=darwin  GOARCH=amd64 go build -trimpath -ldflags="-s -w -buildid=" -o taka-export-darwin-amd64       ./cmd/export
+          env GOOS=darwin  GOARCH=arm64 go build -trimpath -ldflags="-s -w -buildid=" -o taka-export-darwin-arm64       ./cmd/export
+          env GOOS=windows GOARCH=amd64 go build -trimpath -ldflags="-s -w -buildid=" -o taka-export-windows-amd64.exe  ./cmd/export
 
       # --- UPLOAD EVERYTHING ---
       - name: Upload to Release
@@ -59,3 +70,7 @@ jobs:
             taka-dashboard-darwin-amd64
             taka-dashboard-darwin-arm64
             taka-dashboard-windows-amd64.exe
+            taka-export-linux-amd64
+            taka-export-darwin-amd64
+            taka-export-darwin-arm64
+            taka-export-windows-amd64.exe

--- a/cmd/export/main.go
+++ b/cmd/export/main.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"time"
+
+	exporter "github.com/Rtarun3606k/TakaTime/internal/Exporter"
+	"github.com/Rtarun3606k/TakaTime/internal/db"
+	"github.com/Rtarun3606k/TakaTime/internal/types"
+)
+
+// dateLayout is the format accepted by --from and --to flags.
+const dateLayout = "2006-01-02"
+
+func main() {
+	// ── Flags ──────────────────────────────────────────────────────────────────
+	uri     := flag.String("uri", "", "MongoDB connection URI (falls back to $MONGO_URI)")
+	format  := flag.String("format", "csv", "Output format: csv | json")
+	fromStr := flag.String("from", "", "Start date inclusive, YYYY-MM-DD (optional)")
+	toStr   := flag.String("to", "", "End date inclusive, YYYY-MM-DD (optional)")
+	output  := flag.String("output", "", "Output file path (default: stdout)")
+	version := flag.Bool("version", false, "Print version and exit")
+	flag.Parse()
+
+	if *version {
+		fmt.Println(types.Version)
+		return
+	}
+
+	// ── Validate --format ──────────────────────────────────────────────────────
+	if *format != "csv" && *format != "json" {
+		fmt.Fprintf(os.Stderr, "error: --format must be 'csv' or 'json', got %q\n", *format)
+		os.Exit(1)
+	}
+
+	// ── Resolve MongoDB URI ────────────────────────────────────────────────────
+	mongoURI := *uri
+	if mongoURI == "" {
+		mongoURI = os.Getenv("MONGO_URI")
+	}
+	if mongoURI == "" {
+		fmt.Fprintln(os.Stderr, "error: MongoDB URI required — pass --uri or set $MONGO_URI")
+		os.Exit(1)
+	}
+
+	// ── Parse date flags ───────────────────────────────────────────────────────
+	var from, to time.Time
+	if *fromStr != "" {
+		t, err := time.Parse(dateLayout, *fromStr)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: --from %q is not a valid date (expected YYYY-MM-DD)\n", *fromStr)
+			os.Exit(1)
+		}
+		from = t
+	}
+	if *toStr != "" {
+		t, err := time.Parse(dateLayout, *toStr)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: --to %q is not a valid date (expected YYYY-MM-DD)\n", *toStr)
+			os.Exit(1)
+		}
+		to = t
+	}
+	if !from.IsZero() && !to.IsZero() && to.Before(from) {
+		fmt.Fprintln(os.Stderr, "error: --to must not be before --from")
+		os.Exit(1)
+	}
+
+	// ── Connect to MongoDB ─────────────────────────────────────────────────────
+	client, err := db.ConnectToDataBase(mongoURI)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: could not connect to MongoDB: %v\n", err)
+		os.Exit(1)
+	}
+	defer client.Disconnect(context.Background())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// ── Fetch logs ─────────────────────────────────────────────────────────────
+	rows, err := exporter.FetchAllLogs(ctx, client, exporter.FilterOptions{
+		From: from,
+		To:   to,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: failed to fetch logs: %v\n", err)
+		os.Exit(1)
+	}
+
+	// ── Open output destination ────────────────────────────────────────────────
+	dest := os.Stdout
+	if *output != "" {
+		dir := filepath.Dir(*output)
+		if dir != "." && dir != "" {
+			if err := os.MkdirAll(dir, 0755); err != nil {
+				fmt.Fprintf(os.Stderr, "error: cannot create output directory %q: %v\n", dir, err)
+				os.Exit(1)
+			}
+		}
+		f, err := os.Create(*output)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: cannot create output file %q: %v\n", *output, err)
+			os.Exit(1)
+		}
+		defer f.Close()
+		dest = f
+	}
+
+	// ── Write ──────────────────────────────────────────────────────────────────
+	switch *format {
+	case "csv":
+		if err := exporter.WriteCSV(dest, rows); err != nil {
+			fmt.Fprintf(os.Stderr, "error: CSV write failed: %v\n", err)
+			os.Exit(1)
+		}
+	case "json":
+		if err := exporter.WriteJSON(dest, rows); err != nil {
+			fmt.Fprintf(os.Stderr, "error: JSON write failed: %v\n", err)
+			os.Exit(1)
+		}
+	}
+
+	// ── Done ───────────────────────────────────────────────────────────────────
+	if *output != "" {
+		fmt.Fprintf(os.Stderr, "✅  Exported %d records → %s\n", len(rows), *output)
+	} else {
+		log.Printf("exported %d records", len(rows))
+	}
+}

--- a/internal/Exporter/exporter.go
+++ b/internal/Exporter/exporter.go
@@ -1,0 +1,171 @@
+// Package exporter provides data-fetching and serialisation helpers for the
+// taka-export CLI binary.  It is intentionally kept separate from the rest of
+// the TakaTime internals so the export concern stays self-contained and easy
+// to test without pulling in image-generation or dashboard dependencies.
+package exporter
+ 
+import (
+	"context"
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strconv"
+	"time"
+ 
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+)
+ 
+// ── Data types ────────────────────────────────────────────────────────────────
+ 
+// LogRow is a single raw log entry in export-friendly form.
+// The Timestamp field is serialised as RFC3339 UTC so downstream tools
+// (pandas, Excel) parse it unambiguously.
+type LogRow struct {
+	Timestamp string  `json:"timestamp"        csv:"timestamp"`
+	Date      string  `json:"date"             csv:"date"`
+	FileName  string  `json:"file_name"        csv:"file_name"`
+	Project   string  `json:"project"          csv:"project"`
+	Language  string  `json:"language"         csv:"language"`
+	Editor    string  `json:"editor"           csv:"editor"`
+	OS        string  `json:"os"               csv:"os"`
+	GitBranch string  `json:"git_branch"       csv:"git_branch"`
+	Duration  float64 `json:"duration_seconds" csv:"duration_seconds"`
+}
+ 
+// rawDoc mirrors the MongoDB document structure; used only during the fetch.
+type rawDoc struct {
+	Timestamp time.Time `bson:"timestamp"`
+	Date      string    `bson:"date"`
+	FileName  string    `bson:"name"`
+	Project   string    `bson:"project"`
+	Language  string    `bson:"language"`
+	Editor    string    `bson:"editor"`
+	OS        string    `bson:"os"`
+	GitBranch string    `bson:"gitBranch"`
+	Duration  float64   `bson:"duration"`
+}
+ 
+// FilterOptions controls which documents are returned by FetchAllLogs.
+type FilterOptions struct {
+	// From and To are inclusive date boundaries (zero value = unbounded).
+	From time.Time
+	To   time.Time
+}
+ 
+// ── Fetch ─────────────────────────────────────────────────────────────────────
+ 
+// FetchAllLogs queries the takatime.logs collection and returns every matching
+// document as a slice of LogRow values, ordered by timestamp ascending.
+//
+// Both FilterOptions boundaries are inclusive and optional:
+//   - From zero  → no lower bound
+//   - To   zero  → no upper bound
+func FetchAllLogs(ctx context.Context, client *mongo.Client, opts FilterOptions) ([]LogRow, error) {
+	collection := client.Database("takatime").Collection("logs")
+ 
+	// Build the date-range filter only when bounds are actually set.
+	tsFilter := bson.D{}
+	if !opts.From.IsZero() {
+		tsFilter = append(tsFilter, bson.E{Key: "$gte", Value: opts.From})
+	}
+	if !opts.To.IsZero() {
+		// Make --to inclusive by advancing to the end of that calendar day.
+		inclusive := opts.To.Truncate(24 * time.Hour).Add(24*time.Hour - time.Nanosecond)
+		tsFilter = append(tsFilter, bson.E{Key: "$lte", Value: inclusive})
+	}
+ 
+	filter := bson.D{}
+	if len(tsFilter) > 0 {
+		filter = append(filter, bson.E{Key: "timestamp", Value: tsFilter})
+	}
+ 
+	cursor, err := collection.Find(ctx, filter)
+	if err != nil {
+		return nil, fmt.Errorf("mongo find: %w", err)
+	}
+	defer cursor.Close(ctx)
+ 
+	var docs []rawDoc
+	if err := cursor.All(ctx, &docs); err != nil {
+		return nil, fmt.Errorf("cursor decode: %w", err)
+	}
+ 
+	// Sort ascending by timestamp so CSV/JSON output is chronological.
+	sort.Slice(docs, func(i, j int) bool {
+		return docs[i].Timestamp.Before(docs[j].Timestamp)
+	})
+ 
+	rows := make([]LogRow, len(docs))
+	for i, d := range docs {
+		rows[i] = LogRow{
+			Timestamp: d.Timestamp.UTC().Format(time.RFC3339),
+			Date:      d.Date,
+			FileName:  d.FileName,
+			Project:   d.Project,
+			Language:  d.Language,
+			Editor:    d.Editor,
+			OS:        d.OS,
+			GitBranch: d.GitBranch,
+			Duration:  d.Duration,
+		}
+	}
+	return rows, nil
+}
+ 
+// ── Writers ───────────────────────────────────────────────────────────────────
+ 
+// csvHeader defines the canonical column order, matching the issue spec.
+var csvHeader = []string{
+	"timestamp",
+	"date",
+	"file_name",
+	"project",
+	"language",
+	"editor",
+	"os",
+	"git_branch",
+	"duration_seconds",
+}
+ 
+// WriteCSV serialises rows into RFC 4180-compliant CSV, safe to open directly
+// in Excel and load with pandas (pd.read_csv).
+func WriteCSV(w io.Writer, rows []LogRow) error {
+	cw := csv.NewWriter(w)
+ 
+	if err := cw.Write(csvHeader); err != nil {
+		return fmt.Errorf("csv header write: %w", err)
+	}
+ 
+	for _, r := range rows {
+		record := []string{
+			r.Timestamp,
+			r.Date,
+			r.FileName,
+			r.Project,
+			r.Language,
+			r.Editor,
+			r.OS,
+			r.GitBranch,
+			strconv.FormatFloat(r.Duration, 'f', 2, 64),
+		}
+		if err := cw.Write(record); err != nil {
+			return fmt.Errorf("csv row write: %w", err)
+		}
+	}
+ 
+	cw.Flush()
+	return cw.Error()
+}
+ 
+// WriteJSON serialises rows into a pretty-printed JSON array.
+func WriteJSON(w io.Writer, rows []LogRow) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(rows); err != nil {
+		return fmt.Errorf("json encode: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
## Description

This PR adds a new `taka-export` CLI command that enables exporting TakaTime logs from MongoDB in both CSV and JSON formats.

### Changes Made

* Added `internal/Exporter/exporter.go`

  * Fetches logs from MongoDB
  * Supports optional date range filtering (`--from`, `--to`)
  * Provides CSV and JSON serialization helpers

* Added `cmd/export/main.go`

  * New CLI entry point for exporting data
  * Supports:

    * `--format csv|json`
    * `--from YYYY-MM-DD`
    * `--to YYYY-MM-DD`
    * `--output <file>`
    * `--version`

* Updated `.github/workflows/release.yml`

  * Includes build and release support for the new `taka-export` binary

### Example Usage

```bash
taka-export --format csv
taka-export --format json
taka-export --from 2025-04-01 --to 2025-04-30 --output april.json
```

### Issue

Closes #56
