### PR TITLE
fix(upload): check correct error variable after SQLite init

### DIFF
--- a/cmd/upload/main.go
+++ b/cmd/upload/main.go
@@ -45,7 +45,7 @@ func main() {
 
 	var errr error
 	types.DB, errr = db.InitSQLite()
-	if err != nil {
+	if errr != nil {
 		log.Fatal("Could not initialize local DB:", errr)
 	}
 	defer types.DB.Close()


### PR DESCRIPTION
### Description
In `cmd/upload/main.go`, the return error from SQLite initialization is stored in `errr`. However, the code was checking the previously defined `err` variable instead of `errr`. 

This meant that if SQLite initialization failed, the error would go undetected and the program would panic later with a nil pointer dereference when attempting to access `types.DB`.

This PR corrects the `if` check to inspect `errr`.

### Related Changes
- Modified `cmd/upload/main.go` to check `errr != nil`.
- Verified compilation with `go build ./cmd/upload`.

Fix - #58 
