### PR TITLE
feat: add clipboard toast notification to web generator

### DIFF
--- a/docs/index.css
+++ b/docs/index.css
@@ -1222,3 +1222,27 @@ table tbody tr:hover td {
 
   font-size: 0.9rem;
 }
+.toast-notification {
+  position: fixed;
+  bottom: 2rem;
+  right: 2rem;
+  background: #161b22;
+  border: 1px solid rgba(57, 255, 20, 0.4);
+  color: #c9d1d9;
+  padding: 0.85rem 1.4rem;
+  border-radius: 12px;
+  font-size: 0.9rem;
+  font-weight: 500;
+  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.4),
+              0 0 20px rgba(57, 255, 20, 0.1);
+  z-index: 9999;
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 0.3s ease, transform 0.3s ease;
+  pointer-events: none;
+}
+
+.toast-notification.show {
+  opacity: 1;
+  transform: translateY(0);
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -1634,5 +1634,8 @@ function animateCounter(id, target) {
 
 fetchGitHubStats();
 </script>
+<div id="toast" class="toast-notification" aria-live="polite">
+  Command Copied!
+</div>
   </body>
 </html>

--- a/docs/index.js
+++ b/docs/index.js
@@ -294,6 +294,7 @@ Object.values(inputs).forEach((input) => {
 
 copyBtn.addEventListener("click", () => {
   navigator.clipboard.writeText(output.value);
+
   const orig = copyBtnText.innerText;
   copyBtnText.innerText = "Copied! ✨";
   copyBtn.classList.remove("bg-[#238636]", "hover:bg-[#2ea043]");
@@ -303,6 +304,11 @@ copyBtn.addEventListener("click", () => {
     copyBtn.classList.add("bg-[#238636]", "hover:bg-[#2ea043]");
     copyBtn.classList.remove("bg-emerald-600", "hover:bg-emerald-500");
   }, 2000);
+
+  // Toast
+  const toast = document.getElementById("toast");
+  toast.classList.add("show");
+  setTimeout(() => toast.classList.remove("show"), 3000);
 });
 
 const defaultTheme = {


### PR DESCRIPTION
Closes #40 

## Summary
Adds a  toast notification to the Interactive Web Generator 
that appears when the user clicks the "Copy Command" button, confirming 
the CLI command was copied to clipboard.

## Changes
- docs/index.html. added a <div id="toast"> element before </body>
- index.css. added .toast-notification and .toast-notification.show` 
  styles with fade-in and slide-up animation
- docs/index.js — updated the copyBtn click handler to trigger the toast 
  on click and auto-dismiss after 3 seconds

## Behaviour
- Toast appears at the bottom-right of the screen on copy
- Slides up and fades in smoothly (0.3s transition)
- Auto-dismisses after 3 seconds
- Styled to match the existing dark theme with a subtle green border glow
- pointer-events: none ensures it never blocks any clicks
- aria-live="polite" added for screen reader accessibility

Tested locally
 
<img width="1467" height="1012" alt="Screenshot 2026-06-04 151250" src="https://github.com/user-attachments/assets/034e841e-8e86-4a46-989a-793760522480" />
