### PR TITLE
fix: propagate active theme to stats bar colors

### DIFF
--- a/cmd/dashboard/database.go
+++ b/cmd/dashboard/database.go
@@ -7,7 +7,6 @@ import (
 
 	dbqueryv2 "github.com/Rtarun3606k/TakaTime/internal/DBQueryV2"
 	"github.com/Rtarun3606k/TakaTime/internal/db"
-	"github.com/Rtarun3606k/TakaTime/internal/types"
 	"go.mongodb.org/mongo-driver/v2/mongo"
 )
 
@@ -21,7 +20,7 @@ func (m Model) GetData(URI string) (Model, *mongo.Client, error) {
 	}
 
 	for _, value := range labels {
-		data, err := dbqueryv2.GetListStats(Client, value, 30, types.CatppuccinTheme, 0)
+		data, err := dbqueryv2.GetListStats(Client, value, 30, m.TUITheme, 0)
 		if err != nil {
 			log.Println("Failed to fetch stats for", value, ":", err)
 			return m, nil, err

--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -39,7 +39,7 @@ func (m Model) Init() tea.Cmd {
 		return m.Spinner.Tick
 	}
 	// Start spinning the spinner and tell Bubble Tea to fetch data in the background!
-	return tea.Batch(m.Spinner.Tick, fetchData(m.MongoURI))
+	return tea.Batch(m.Spinner.Tick, fetchData(m.MongoURI, m.TUITheme))
 }
 
 func main() {

--- a/cmd/dashboard/update.go
+++ b/cmd/dashboard/update.go
@@ -16,7 +16,9 @@ type dataLoadedMsg struct {
 	FromCache    bool
 }
 
-func fetchData(uri string) tea.Cmd {
+// fetchData loads dashboard data asynchronously, resolving the active theme from
+// SQLite config when available and falling back to fallbackTheme (the --theme flag value).
+func fetchData(uri string, fallbackTheme types.ThemeConfig) tea.Cmd {
 	return func() tea.Msg {
 		// Initialize SQLite connection
 		sqliteDB, err := db.InitSQLite()
@@ -26,17 +28,16 @@ func fetchData(uri string) tea.Cmd {
 		}
 		defer sqliteDB.Close()
 
-		// 👉 NEW 1: Load the Config and Compile the Styles
-		var loadedStyles Styles.AppStyles
-		userConfig, err := db.LoadConfig(sqliteDB)
-
-		if err == nil && userConfig.Theme != "" {
-			// We found a saved theme! Compile it.
-			loadedStyles = Styles.BuildStyles(utils.ThemeSwitcher(userConfig.Theme))
+		// Resolve the active theme: prefer the saved SQLite config, fall back to
+		// the theme provided via the --theme flag.
+		var activeTheme types.ThemeConfig
+		userConfig, configErr := db.LoadConfig(sqliteDB)
+		if configErr == nil && userConfig.Theme != "" {
+			activeTheme = utils.ThemeSwitcher(userConfig.Theme)
 		} else {
-			// No saved config yet? Default to sunset!
-			loadedStyles = Styles.BuildStyles(utils.ThemeSwitcher("sunset"))
+			activeTheme = fallbackTheme
 		}
+		loadedStyles := Styles.BuildStyles(activeTheme)
 
 		// Check Cache First
 		cachedData, err := db.GetDashboardCache(sqliteDB)
@@ -59,7 +60,7 @@ func fetchData(uri string) tea.Cmd {
 		}
 
 		// Cache MISS! Fetch fresh from MongoDB
-		tempModel := Model{}
+		tempModel := Model{TUITheme: activeTheme}
 		filledModel, _, err := tempModel.GetData(uri)
 
 		// 👉 NEW 3: Attach styles to the Cache MISS model before returning it
@@ -222,17 +223,25 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					sqliteDB.Close()
 				}
 
-				// 3. Rebuild the AppStyles locally using the new colors
+				// 3. Rebuild the AppStyles locally using the new colors and persist the
+			// selected theme so GetData uses it for stat bar colors.
 				m.AppStyles = Styles.BuildStyles(newThemeConfig)
+				m.TUITheme = newThemeConfig
 				m.ShowSettings = false
 
-				// 4. Force the viewport to redraw with the new colors!
+				// 4. Clear stale cache so the next fetch re-colors bars with the new theme.
+				if sqliteDB2, err2 := db.InitSQLite(); err2 == nil {
+					db.ClearDashboardCache(sqliteDB2)
+					sqliteDB2.Close()
+				}
+
+				// 5. Force the viewport to redraw with the new colors!
 				if m.Ready {
 					m.updateViewport()
 				}
 			}
 			m.Loading = true
-			return m, fetchData(m.MongoURI)
+			return m, fetchData(m.MongoURI, m.TUITheme)
 		}
 
 		switch msg.String() {
@@ -240,7 +249,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 		case "r":
 			m.Loading = true
-			return m, fetchData(m.MongoURI)
+			return m, fetchData(m.MongoURI, m.TUITheme)
 
 		case "m":
 			// Toggle the boolean (True becomes False, False becomes True)

--- a/internal/db/localDB.go
+++ b/internal/db/localDB.go
@@ -161,6 +161,12 @@ func SaveDashboardCache(db *sql.DB, data types.CacheData) error {
 	return err
 }
 
+// ClearDashboardCache deletes the cached dashboard data, forcing a fresh fetch
+func ClearDashboardCache(db *sql.DB) error {
+	_, err := db.Exec("DELETE FROM dashboard_cache WHERE id = 'main'")
+	return err
+}
+
 // GetDashboardCache checks if data exists and is less than 5 minutes old
 func GetDashboardCache(db *sql.DB) (*types.CacheData, error) {
 	var rawJSON string


### PR DESCRIPTION
## Problem
Stats bar colors (Language, Project, OS, Editor) were permanently locked 
to the Catppuccin palette regardless of the `--theme` flag or the 
in-dashboard settings menu.

## Root Cause
- `database.go` line 24: `GetListStats` was called with hardcoded 
  `types.CatppuccinTheme` instead of `m.TUITheme`
- `update.go`: `fetchData` created `tempModel := Model{}` (zero-value), 
  so the resolved theme never reached `GetData`

## Changes
- Replace hardcoded `CatppuccinTheme` with `m.TUITheme` in `GetData`
- `fetchData` now resolves active theme from SQLite config, falling back 
  to the `--theme` flag value
- `m.TUITheme` is updated when user changes theme via settings menu
- Dashboard cache is cleared on theme change to force re-colored fresh fetch
- Added `ClearDashboardCache` helper to `localDB.go`

Fixes #61
