### PR TITLE
test: add editor flag assertion for getGoArgs

### DIFF
--- a/vscodePlugin/Takatime/test/uploader.test.js
+++ b/vscodePlugin/Takatime/test/uploader.test.js
@@ -1,0 +1,71 @@
+const assert = require('assert');
+
+// Mock vscode module
+const mockVscode = {
+  env: {
+    appName: 'Visual Studio Code'
+  },
+  workspace: {
+    getWorkspaceFolder: () => null
+  }
+};
+
+// Override require for vscode
+const Module = require('module');
+const originalRequire = Module.prototype.require;
+Module.prototype.require = function(id) {
+  if (id === 'vscode') {
+    return mockVscode;
+  }
+  return originalRequire.apply(this, arguments);
+};
+
+// Now require the uploader module
+const { getGoArgs } = require('../Plugin/Uploader');
+
+suite('Uploader Test Suite', () => {
+  test('getGoArgs returns VS Code editor flag for standard VS Code', () => {
+    mockVscode.env.appName = 'Visual Studio Code';
+    const mockDoc = { fileName: '/test/file.js', languageId: 'javascript' };
+    const args = getGoArgs(mockDoc, 'mongodb://test');
+    const editorIndex = args.indexOf('-editor');
+    assert.notStrictEqual(editorIndex, -1);
+    assert.strictEqual(args[editorIndex + 1], 'VS Code');
+  });
+
+  test('getGoArgs returns VS Code editor flag for VS Code Insiders', () => {
+    mockVscode.env.appName = 'Visual Studio Code - Insiders';
+    const mockDoc = { fileName: '/test/file.js', languageId: 'javascript' };
+    const args = getGoArgs(mockDoc, 'mongodb://test');
+    const editorIndex = args.indexOf('-editor');
+    assert.notStrictEqual(editorIndex, -1);
+    assert.strictEqual(args[editorIndex + 1], 'VS Code');
+  });
+
+  test('getGoArgs returns Cursor editor flag for Cursor', () => {
+    mockVscode.env.appName = 'Cursor';
+    const mockDoc = { fileName: '/test/file.js', languageId: 'javascript' };
+    const args = getGoArgs(mockDoc, 'mongodb://test');
+    const editorIndex = args.indexOf('-editor');
+    assert.notStrictEqual(editorIndex, -1);
+    assert.strictEqual(args[editorIndex + 1], 'Cursor');
+  });
+
+  test('getGoArgs returns Windsurf editor flag for Windsurf', () => {
+    mockVscode.env.appName = 'Windsurf';
+    const mockDoc = { fileName: '/test/file.js', languageId: 'javascript' };
+    const args = getGoArgs(mockDoc, 'mongodb://test');
+    const editorIndex = args.indexOf('-editor');
+    assert.notStrictEqual(editorIndex, -1);
+    assert.strictEqual(args[editorIndex + 1], 'Windsurf');
+  });
+
+  test('getGoArgs returns Antigravity for unknown editor', () => {
+    mockVscode.env.appName = 'SomeUnknownEditor';
+    const mockDoc = { fileName: '/test/file.js', languageId: 'javascript' };
+    const args = getGoArgs(mockDoc, 'mongodb://test');
+    const editorIndex = args.indexOf('-editor');
+    assert.notStrictEqual(editorIndex, -1);
+    assert.strictEqual(args[editorIndex + 1], 'Antigravity');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds unit tests for `getGoArgs()` to verify the `-editor` flag value
- Tests cover VS Code, VS Code Insiders, Cursor, Windsurf, and unknown editors

## Problem

Issue #66 reported that the VS Code extension was sending `-editor Antigravity` instead of the correct editor name. The core fix was merged in PR #74 (adding `getCleanEditorName()`), but no tests were added to prevent regression.

## Changes

- `vscodePlugin/Takatime/test/uploader.test.js`: New test file with 5 test cases for `getGoArgs()` editor flag

## Files Changed

- `vscodePlugin/Takatime/test/uploader.test.js` (+71, -0)

## Testing Performed

- All 5 tests pass: VS Code → "VS Code", Insiders → "VS Code", Cursor → "Cursor", Windsurf → "Windsurf", Unknown → "Antigravity"

Closes #66
