### PR TITLE
Fix(neovim): audit Lua API usage, prevent timer leaks, and ensure lazy.nvim compatibility

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -81,12 +81,9 @@ Add the plugin to your Lazy.nvim configuration:
 return {
   "Rtarun3606k/TakaTime",
   lazy = false,
-  config = function()
-    -- Optional: enable debug mode if needed
-    require("taka-time").setup({
-      debug = false
-    })
-  end,
+  opts = {
+    -- debug = false,  -- set to true for verbose logging
+  },
 }
 ```
 

--- a/lua/taka-time/core.lua
+++ b/lua/taka-time/core.lua
@@ -134,14 +134,18 @@ function M.setup_listeners()
 end
 
 -------------------------------------------------------------------------------------
--- Public: Called on Exit
-function M.on_exit()
-	-- Stop the background sync timer
+function M.clear_timer()
 	if state.timer then
 		state.timer:stop()
 		state.timer:close()
 		state.timer = nil
 	end
+end
+
+-- Public: Called on Exit
+function M.on_exit()
+	-- Stop the background sync timer
+	M.clear_timer()
 
 	-- 1. Snapshot the time immediately
 	local time_to_send = state.pending_duration
@@ -190,11 +194,7 @@ end
 
 function M.start_timer()
 	-- Stop any previously running timer to prevent duplicates on re-setup
-	if state.timer then
-		state.timer:stop()
-		state.timer:close()
-		state.timer = nil
-	end
+	M.clear_timer()
 
 	state.timer = uv.new_timer()
 	state.timer:start(

--- a/lua/taka-time/core.lua
+++ b/lua/taka-time/core.lua
@@ -125,6 +125,12 @@ function M.setup_listeners()
 			attempt_upload()
 		end,
 	})
+
+	-- On Exit, flush any remaining data
+	vim.api.nvim_create_autocmd("VimLeavePre", {
+		group = group,
+		callback = M.on_exit,
+	})
 end
 
 -------------------------------------------------------------------------------------

--- a/lua/taka-time/core.lua
+++ b/lua/taka-time/core.lua
@@ -80,7 +80,17 @@ local function attempt_upload()
 			end
 		end,
 	})
+
+	-- jobstart returns 0 or -1 on failure; on_exit won't fire in that case
+	if state.job_id <= 0 then
+		state.job_id = 0
+		state.pending_duration = state.pending_duration + time_to_send
+		if config.options.debug then
+			print("[Taka] Failed to start upload process.")
+		end
+	end
 end
+
 
 -----------------------------------------------------------------------------------
 --  THE FIX: Only add time if activity happened recently

--- a/lua/taka-time/core.lua
+++ b/lua/taka-time/core.lua
@@ -1,6 +1,7 @@
 local M = {}
 local config = require("taka-time.config")
 local utils = require("taka-time.utils")
+local uv = vim.uv or vim.loop
 
 -- STATE
 local state = {
@@ -179,7 +180,7 @@ function M.start_timer()
 		state.timer = nil
 	end
 
-	state.timer = vim.loop.new_timer()
+	state.timer = uv.new_timer()
 	state.timer:start(
 		1000, -- Wait 1s
 		60000, -- Repeat every 60s

--- a/lua/taka-time/core.lua
+++ b/lua/taka-time/core.lua
@@ -7,6 +7,7 @@ local state = {
 	last_event_time = os.time(), -- When was the last keystroke?
 	pending_duration = 0, -- Accumulated seconds to send
 	job_id = 0,
+	timer = nil, -- Background sync timer handle
 }
 
 -- TIMEOUT: If no activity for 2 mins, don't count that time gap.
@@ -118,6 +119,13 @@ end
 -------------------------------------------------------------------------------------
 -- Public: Called on Exit
 function M.on_exit()
+	-- Stop the background sync timer
+	if state.timer then
+		state.timer:stop()
+		state.timer:close()
+		state.timer = nil
+	end
+
 	-- 1. Snapshot the time immediately
 	local time_to_send = state.pending_duration
 
@@ -164,8 +172,15 @@ function M.on_exit()
 end
 
 function M.start_timer()
-	local timer = vim.loop.new_timer()
-	timer:start(
+	-- Stop any previously running timer to prevent duplicates on re-setup
+	if state.timer then
+		state.timer:stop()
+		state.timer:close()
+		state.timer = nil
+	end
+
+	state.timer = vim.loop.new_timer()
+	state.timer:start(
 		1000, -- Wait 1s
 		60000, -- Repeat every 60s
 		vim.schedule_wrap(function()

--- a/lua/taka-time/init.lua
+++ b/lua/taka-time/init.lua
@@ -161,15 +161,6 @@ function M.setup(opts)
 
   -- Start the background sync timer
   core.start_timer()
-
-  -- 6. Exit Handler
-  -- We still handle Exit explicitly here or inside core.
-  -- Since core.on_exit is public, this is fine, OR core.setup_listeners can handle it.
-  -- But usually VimLeavePre is safer in init.lua for plugin lifecycle.
-  vim.api.nvim_create_autocmd("VimLeavePre", {
-    group = vim.api.nvim_create_augroup("TakaTimeExit", { clear = true }),
-    callback = core.on_exit,
-  })
 end
 
 return M

--- a/lua/taka-time/utils.lua
+++ b/lua/taka-time/utils.lua
@@ -164,7 +164,6 @@ end
 
 -- Helper: Check if the current directory is inside an ignored repository
 function M.is_ignored(current_dir)
-	local config = require("taka-time.config")
 	local ignore_list = config.options.ignore_repos or {}
 
 	-- Add a slash to the current directory for safe comparison

--- a/lua/taka-time/utils.lua
+++ b/lua/taka-time/utils.lua
@@ -1,5 +1,6 @@
 local M = {}
 local config = require("taka-time.config")
+local uv = vim.uv or vim.loop
 
 ---@enum BinaryEnum
 M.BinaryEnum = {
@@ -11,7 +12,7 @@ function M.get_binary_path(binary)
 	local plugin_root = vim.fn.fnamemodify(debug.getinfo(1).source:sub(2), ":h:h:h")
 	local bin_path = plugin_root .. "/" .. binary
 
-	local os_name = vim.loop.os_uname().sysname:lower()
+	local os_name = uv.os_uname().sysname:lower()
 	if string.match(os_name, "windows") ~= nil then
 		bin_path = bin_path .. ".exe"
 	end
@@ -71,7 +72,7 @@ end
 
 -- Helper: Detect OS/Arch
 local function get_os_info()
-	local uname = vim.loop.os_uname()
+	local uname = uv.os_uname()
 	local os = uname.sysname:lower()
 	local arch = uname.machine:lower()
 	if os == "linux" then
@@ -146,7 +147,7 @@ end
 -----------------------------------------------------------------------------------------
 
 function M.get_os()
-	local os_name = vim.loop.os_uname().sysname
+	local os_name = uv.os_uname().sysname
 
 	print(os_name, " os name")
 	return os_name


### PR DESCRIPTION
Resolves #43

### Description
This PR addresses the Neovim API audit requirements, focusing on long-term compatibility with Neovim 0.10+ and fixing critical bugs related to background job execution and resource leaks during plugin reloads.

### Changes Made
- **API Migration:** Replaced all deprecated `vim.loop` calls with a backwards-compatible `vim.uv or vim.loop` shim, ensuring the plugin works flawlessly on Neovim 0.9, 0.10+, and Nightly.
- **Fixed Timer Leaks:** Background sync timers created via `start_timer()` were previously orphaned. They are now stored in state, properly guarded against duplicates on `setup()` re-entry (e.g., via `lazy.nvim` reloads), and cleaned up securely on exit.
- **Fixed Persistent Upload Blockage:** Addressed a critical bug where `vim.fn.jobstart()` returning `-1` (e.g., when the Go binary hasn't downloaded yet or is blocked) would permanently hang the `state.job_id`, blocking all future upload attempts.
- **Autocmd Consolidation:** Moved the `VimLeavePre` event into the main `TakaTimeGroup` augroup. This prevents memory leaks and orphaned events by ensuring `{ clear = true }` cleans up the entire plugin lifecycle gracefully.
- **Code Quality:** Removed unintended variable shadowing in `utils.lua`.
- **Documentation:** Updated the `lazy.nvim` installation guide in `INSTALL.md` to use the community-standard `opts = {}` pattern instead of `config = function()`.

### Testing
- ✅ Verified on Neovim v0.12.2.
- ✅ Tested headless and interactive loading via `lazy.nvim` to ensure no `vim.uv` errors occur.
- ✅ Asserted that all 7 `autocmd` events correctly group into `TakaTimeGroup`.
- ✅ Verified that `jobstart` gracefully handles missing binaries without freezing the state machine.

---
- [x] I confirm this is a substantial contribution, not a trivial spam PR.
