### PR TITLE
[GSSoC'26] fix: print actual UpdateReadMe error in report command

### DIFF
--- a/cmd/report/main.go
+++ b/cmd/report/main.go
@@ -200,7 +200,7 @@ func main() {
 
 		errr := gogist.UpdateReadMe(gistToken, targetRepo, content)
 		if errr != nil {
-			fmt.Println("Some error occured while updating readme ", err)
+			fmt.Println("Some error occured while updating readme ", errr)
 		}
 		fmt.Println("README Updated Successfully!")
 	} else {


### PR DESCRIPTION
## Related Issue

Closes #70

## Description of Changes

Fixed `cmd/report/main.go` to print the actual `errr` variable from `UpdateReadMe()` instead of the stale `err` variable, so users see the real failure cause.

## Files Changed

- `cmd/report/main.go`: Changed `err` to `errr` in error message

## Testing Notes

- [x] Changes tested locally
- [x] Verified report command now shows actual UpdateReadMe error

## PR Checklist

- [x] Branch is synced with the latest `upstream/main` and all conflicts are resolved
- [x] Code is production-ready and tested locally
- [x] Existing code conventions are followed
- [x] Commits follow the [Conventional Commits](https://www.conventionalcommits.org/) style
