### PR TITLE
[GSSoC'26] fix: use local midnight for yesterday stats boundary

### DIFF
--- a/internal/DBQueryV2/aggration.go
+++ b/internal/DBQueryV2/aggration.go
@@ -170,7 +170,7 @@ func GetTimeStats(client *mongo.Client) (types.TimeGridStruct, error) {
 
 	// 2. Define Time Boundaries
 	now := time.Now()
-	yesterdayStart := now.AddDate(0, 0, -1).Truncate(24 * time.Hour)
+	yesterdayStart := time.Date(now.Year(), now.Month(), now.Day()-1, 0, 0, 0, 0, now.Location())
 	yesterdayEnd := yesterdayStart.Add(24 * time.Hour)
 	weekAgo := now.AddDate(0, 0, -7)
 	monthAgo := now.AddDate(0, 0, -30)


### PR DESCRIPTION
## Related Issue

Closes #68

## Description of Changes

Fixed `internal/DBQueryV2/aggration.go` to use `time.Date()` with local timezone for yesterday's start boundary instead of `Truncate(24 * time.Hour)` which aligned to UTC, fixing incorrect totals for users outside UTC.

## Files Changed

- `internal/DBQueryV2/aggration.go`: Replaced `Truncate(24 * time.Hour)` with `time.Date()` using local timezone

## Testing Notes

- [x] Changes tested locally
- [x] Verified yesterday stats use local midnight boundary

## PR Checklist

- [x] Branch is synced with the latest `upstream/main` and all conflicts are resolved
- [x] Code is production-ready and tested locally
- [x] Existing code conventions are followed
- [x] Commits follow the [Conventional Commits](https://www.conventionalcommits.org/) style
