### PR TITLE
docs: fix inconsistent repo casing in Total Downloads badge links

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@
   <img src="https://img.shields.io/github/license/Rtarun3606k/TakaTime?style=for-the-badge&color=blue" alt="License">
 </a>
 
-<a href="https://github.com/rtarun3606k/Takatime/releases">
-  <img src="https://img.shields.io/github/downloads/rtarun3606k/Takatime/total?style=for-the-badge&color=blue&logo=github" alt="Total Downloads">
+<a href="https://github.com/Rtarun3606k/TakaTime/releases">
+  <img src="https://img.shields.io/github/downloads/Rtarun3606k/TakaTime/total?style=for-the-badge&color=blue&logo=github" alt="Total Downloads">
 </a>
 
 <br>


### PR DESCRIPTION
PR Description: Fixed inconsistent repo casing (rtarun3606k/Takatime → Rtarun3606k/TakaTime) in the Total Downloads badge links in README.md.

Issue: closes #None (just a documentation quick fix )